### PR TITLE
Adding metadata for both batch & stream files

### DIFF
--- a/FastFeast/pipeline/config/files_metadata.yaml
+++ b/FastFeast/pipeline/config/files_metadata.yaml
@@ -377,34 +377,11 @@ stream:
         nullable: false
       - name: 'order_created_at'
         type: 'timestamp'
-        nullable: true
-
-  - file_name: 'ticket_events.json'
-    target_fact: 'FACT_ORDER'
-    write_priority: 2
-    columns:
-      - name: 'event_id'
-        type: 'varchar'
-        pk: true
-        nullable: false
-      - name: 'ticket_id'
-        type: 'varchar'
-        nullable: false
-      - name: 'new_status'
-        type: 'varchar'
-        expected_values: ['Open', 'InProgress', 'Resolved', 'Closed']
-        nullable: false
-      - name: 'event_ts'
-        type: 'timestamp'
-        nullable: false
-      - name: 'notes'
-        type: 'varchar'
-        pii: true
-        nullable: true
+        nullable: true      
 
   - file_name: 'tickets.csv'
     target_fact: 'FACT_ORDER'
-    write_priority: 3
+    write_priority: 2
     columns:
       - name: 'ticket_id'
         type: 'varchar'
@@ -429,3 +406,26 @@ stream:
       - name: 'created_at'
         type: 'timestamp'
         nullable: false
+
+  - file_name: 'ticket_events.json'
+    target_fact: 'FACT_ORDER'
+    write_priority: 3
+    columns:
+      - name: 'event_id'
+        type: 'varchar'
+        pk: true
+        nullable: false
+      - name: 'ticket_id'
+        type: 'varchar'
+        nullable: false
+      - name: 'new_status'
+        type: 'varchar'
+        expected_values: ['Open', 'InProgress', 'Resolved', 'Closed']
+        nullable: false
+      - name: 'event_ts'
+        type: 'timestamp'
+        nullable: false
+      - name: 'notes'
+        type: 'varchar'
+        pii: true
+        nullable: true


### PR DESCRIPTION
The YAML is divided into batch and stream sections, each describing the expected files and their column definitions.

### **A note on Lookup Tables vs. Business Dimensions**

We distinguish between two kinds of batch files:

**Lookup tables** (e.g., cities.json, regions.csv, categories.csv, segments.csv, teams.csv, reason_categories.csv):
These files provide reference data that is used to enrich business dimensions. They are not loaded into gold as separate dimension tables. Instead, during transformation, we join their attributes (e.g., city_name, region_name, team_name) into the corresponding business dimension

**Business dimensions** (e.g., customers.csv, drivers.csv, restaurants.json, agents.csv):
These files have target_dimension defined, meaning they will be transformed and loaded into gold dimension tables (DIM_CUSTOMER, DIM_DRIVER, etc.).

Their columns are validated, PII columns are hashed, and they are enriched with attributes from lookup tables before being upserted into gold.

