### PR TITLE
Implement DLQ routing, orphan retry logic, and config loading

### DIFF
--- a/FastFeast/dwh/silver/orphan_retriever.py
+++ b/FastFeast/dwh/silver/orphan_retriever.py
@@ -28,7 +28,7 @@ def load_and_clear_orphans(table_name:str) -> pa.Table:
         )
         shutil.rmtree(base_dir)  
         log.info(f"Loaded {orphan_table.num_rows} orphan records for retry", table_name=table_name)
-        return orphan_table.drop(['_pipeline_run_id', "_processed_at"])  
+        return orphan_table.drop(['pipeline_run_id', "_processed_at"])  
     except Exception as e:
         log.error(f"Failed to load orphan records: {e}", table_name=table_name)
         return None

--- a/FastFeast/dwh/silver/orphan_retriever.py
+++ b/FastFeast/dwh/silver/orphan_retriever.py
@@ -1,0 +1,34 @@
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.compute as pc
+import shutil 
+from pathlib import Path
+from support.logger import pipeline as log
+from pipeline.config.config import config_settings
+
+def load_and_clear_orphans(table_name:str) -> pa.Table: 
+    """
+    Loads all current orphans for a specific table so they can be retried.
+    Increments their retry count, and DELETES the old orphan files so they 
+    don't get processed twice.    
+    """
+    base_dir = Path(config_settings.paths.output_dir).resolve() / "validation" /  "orphans" / table_name
+    if not base_dir.exists() or not any(base_dir.iterdir()):
+        log.info("No orphan records found", table_name=table_name)
+        return None
+    try: 
+        dataset = ds.dataset(str(base_dir), format="parquet")
+        orphan_table = dataset.to_table()
+
+        new_retry_count = pc.add(orphan_table['_retry_count'], 1)
+        orphan_table = orphan_table.set_column(
+            orphan_table.schema.get_field_index('_retry_count'), 
+            '_retry_count', 
+            new_retry_count
+        )
+        shutil.rmtree(base_dir)  
+        log.info(f"Loaded {orphan_table.num_rows} orphan records for retry", table_name=table_name)
+        return orphan_table.drop(['_pipeline_run_id', "_processed_at"])  
+    except Exception as e:
+        log.error(f"Failed to load orphan records: {e}", table_name=table_name)
+        return None

--- a/FastFeast/dwh/silver/quarantine_manager.py
+++ b/FastFeast/dwh/silver/quarantine_manager.py
@@ -1,0 +1,80 @@
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from datetime import datetime
+from pathlib import Path
+from support.logger import pipeline as log
+from pipeline.config.config import config_settings
+
+#FIXME constant should be moved to config 
+MAX_ORPHAN_RETRIES = 3 
+
+def route_records(table: pa.Table, table_name: str, run_id: str) -> pa.Table:
+    """ 
+    Splits a validated PyArrow table three ways:
+    1. VALID -> Strips metadata and returns for Silver ingestion.
+    2. INVALID -> Routes to the Dead Letter Queue (Quarantine).
+    3. ORPHAN -> Routes to the Orphan Waiting Room.
+    """
+    #NOTE also should be derived from metadata/config
+    required_cols = ['_record_status', '_error_reasons', '_retry_count']
+
+    if not all(col in table.column_names for col in required_cols): 
+        raise ValueError(f"Table {table_name} is missing required validation columns.")
+    
+    num_rows = table.num_rows
+    table = table.append_column('pipeline_run_id' , pa.array([run_id * num_rows]))
+    table = table.append_column("_processed_at", pa.array([datetime.now()] * num_rows, type = pa.timestamp('us')))
+
+    good_table = table.filter(pc.equal(['record_status'], 'VALID'))
+    bad_table = table.filter(pc.equal(['record_status'], 'INVALID'))
+    orphan_table = table.filter(pc.equal(['record_status'], 'ORPHAN'))
+    if orphan_table.num_rows > 0:
+        expired_mask = pc.greater_equal(orphan_table['_retry_count'], MAX_ORPHAN_RETRIES)
+        expired_orphans = orphan_table.filter(expired_mask)
+        active_orphans = orphan_table.filter(pc.invert(expired_mask))
+
+        if expired_orphans.num_rows > 0:
+            log.warning(f"Found {expired_orphans.num_rows} expired orphan records. Routing to DLQ.", table_name=table_name)
+            expired_reasons = pc.utf8_concat([expired_orphans['_error_reasons'], pa.scalar(" | expired_orphan")])
+            expired_orphans = expired_orphans.set_column(
+                expired_orphans.schema.get_field_index('_error_reasons'), 
+                '_error_reasons',
+                expired_reasons
+            )
+            bad_table = pc.concat_tables([bad_table, expired_orphans])
+        
+        if active_orphans.num_rows > 0: 
+            _write_to_storage(active_orphans, table_name, run_id, folder_type = "orphans")
+    if bad_table.num_rows > 0:
+        _write_to_storage(bad_table, table_name, run_id, folder_type = "quarantine")
+    log.info(
+        'Validation routing complete',
+        table_name=table_name,
+        valid_records=good_table.num_rows,
+        invalid_records=bad_table.num_rows,
+        orphans_waiting = (orphan_table.num_rows - expired_orphans.num_rows) if orphan_table.num_rows > 0 else 0,
+        run_id = run_id
+    )
+    if good_table.num_rows == 0:
+        clean_table = good_table.drop([col for col in good_table.column_names if col.startswith('_')])
+        return clean_table
+    return None
+
+def _write_to_storage(table: pa.Table, table_name: str, run_id: str, folder_type: str):
+    """
+    Writes a PyArrow table to the appropriate location in storage based on the folder type (quarantine or orphans).
+    """
+    base_dir = Path(config_settings.paths.output_dir).resolve() / "validation" / folder_type
+    today_str = datetime.now().strftime(config_settings.datetime_handling.date_key_format)
+
+    # Path should be something along the lines of:  /validation/{quarantine_or_orphans}/{table_name}/{YYYY-MM-DD}/{run_id}.parquet 
+    dest_dir = base_dir / table_name / today_str
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    file_path = dest_dir / f"{run_id}.parquet"
+    try: 
+        pq.write_table(table, file_path)
+        log.debug(f"Wrote {table.num_rows} records to {folder_type}", path=str(file_path))
+    except Exception as e:
+        log.error(f"Failed to write {folder_type} file: {e}", path=str(file_path), table_name=table_name, run_id=run_id)
+        raise

--- a/FastFeast/dwh/silver/quarantine_manager.py
+++ b/FastFeast/dwh/silver/quarantine_manager.py
@@ -23,12 +23,13 @@ def route_records(table: pa.Table, table_name: str, run_id: str) -> pa.Table:
         raise ValueError(f"Table {table_name} is missing required validation columns.")
     
     num_rows = table.num_rows
-    table = table.append_column('pipeline_run_id' , pa.array([run_id * num_rows]))
-    table = table.append_column("_processed_at", pa.array([datetime.now()] * num_rows, type = pa.timestamp('us')))
+    table = table.append_column('pipeline_run_id', pa.array([run_id] * num_rows))
+    table = table.append_column("_processed_at", pa.array([datetime.now()] * num_rows, type=pa.timestamp('us')))
 
-    good_table = table.filter(pc.equal(['record_status'], 'VALID'))
-    bad_table = table.filter(pc.equal(['record_status'], 'INVALID'))
-    orphan_table = table.filter(pc.equal(['record_status'], 'ORPHAN'))
+    good_table = table.filter(pc.equal(table['_record_status'], 'VALID'))
+    bad_table = table.filter(pc.equal(table['_record_status'], 'INVALID'))
+    orphan_table = table.filter(pc.equal(table['_record_status'], 'ORPHAN'))
+    expired_orphans = pa.table({})
     if orphan_table.num_rows > 0:
         expired_mask = pc.greater_equal(orphan_table['_retry_count'], MAX_ORPHAN_RETRIES)
         expired_orphans = orphan_table.filter(expired_mask)
@@ -36,13 +37,17 @@ def route_records(table: pa.Table, table_name: str, run_id: str) -> pa.Table:
 
         if expired_orphans.num_rows > 0:
             log.warning(f"Found {expired_orphans.num_rows} expired orphan records. Routing to DLQ.", table_name=table_name)
-            expired_reasons = pc.utf8_concat([expired_orphans['_error_reasons'], pa.scalar(" | expired_orphan")])
+            expired_reasons = pc.binary_join_element_wise(
+                expired_orphans['_error_reasons'],
+                pa.scalar(" | expired_orphan"),
+                pa.scalar("")
+            )
             expired_orphans = expired_orphans.set_column(
                 expired_orphans.schema.get_field_index('_error_reasons'), 
                 '_error_reasons',
                 expired_reasons
             )
-            bad_table = pc.concat_tables([bad_table, expired_orphans])
+            bad_table = pa.concat_tables([bad_table, expired_orphans])
         
         if active_orphans.num_rows > 0: 
             _write_to_storage(active_orphans, table_name, run_id, folder_type = "orphans")
@@ -53,13 +58,14 @@ def route_records(table: pa.Table, table_name: str, run_id: str) -> pa.Table:
         table_name=table_name,
         valid_records=good_table.num_rows,
         invalid_records=bad_table.num_rows,
-        orphans_waiting = (orphan_table.num_rows - expired_orphans.num_rows) if orphan_table.num_rows > 0 else 0,
+        orphans_waiting=(orphan_table.num_rows - expired_orphans.num_rows) if orphan_table.num_rows > 0 else 0,
         run_id = run_id
     )
     if good_table.num_rows == 0:
-        clean_table = good_table.drop([col for col in good_table.column_names if col.startswith('_')])
-        return clean_table
-    return None
+        return None
+
+    clean_table = good_table.drop([col for col in good_table.column_names if col.startswith('_') or col == 'pipeline_run_id'])
+    return clean_table
 
 def _write_to_storage(table: pa.Table, table_name: str, run_id: str, folder_type: str):
     """

--- a/FastFeast/pipeline/config/config.py
+++ b/FastFeast/pipeline/config/config.py
@@ -101,3 +101,9 @@ def load(path: str) -> Settings:
         batch=Batch(**data["batch"]),
         threshold=Threshold(**data["threshold"])
     )
+
+import os
+from pathlib import Path
+
+DEFAULT_CONFIG_PATH = Path(__file__).parent / "config.yaml"
+config_settings = load(str(DEFAULT_CONFIG_PATH))


### PR DESCRIPTION
This pull request introduces new functionality for managing orphan and invalid records in the data warehouse ingestion pipeline. The main changes add robust handling for routing, retrying, and clearing orphaned and invalid records using PyArrow tables, and integrate configuration and logging. 

**Orphan and Quarantine Management Enhancements:**

* Added `route_records` function in `quarantine_manager.py` to split incoming records into valid, invalid (quarantine), and orphan categories, handle retry limits for orphans, and write results to appropriate storage locations.
* Implemented `_write_to_storage` helper function in `quarantine_manager.py` for writing tables to partitioned storage based on record status.
* Added `load_and_clear_orphans` function in `orphan_retriever.py` to load, increment retry counts, and clear orphan records for re-processing, ensuring no duplicate processing.

**Configuration and Logging Integration:**

* Integrated use of `config_settings` for dynamic path and format configuration, and standardized logging throughout new functions for better observability. [[1]](diffhunk://#diff-78f1313b0be2eebbbdf26058990625d1c34643683d4a70fd0e6db9e8399e1b57R1-R34) [[2]](diffhunk://#diff-f0b2c2a8b1d7e9d41d0ba6b0de4b2901f29183cfcb7f04b22c2dc06617a9ed24R1-R86) [[3]](diffhunk://#diff-79671a1a59deea9641cdb6f8ab8201a35a2cbe82a22ed052a872730dc428a79aR104-R109)
* Set up default config loading at module level in `config.py` to ensure `config_settings` is always available.